### PR TITLE
fix: protect partial.tpl

### DIFF
--- a/partial.go
+++ b/partial.go
@@ -10,6 +10,7 @@ type partial struct {
 	name   string
 	source string
 	tpl    *Template
+	mu     sync.RWMutex // protects tpl
 }
 
 // partials stores all global partials
@@ -88,14 +89,17 @@ func findPartial(name string) *partial {
 
 // template returns parsed partial template
 func (p *partial) template() (*Template, error) {
+	var err error
+
+	p.mu.RLock()
 	if p.tpl == nil {
-		var err error
-
+		p.mu.RUnlock()
+		p.mu.Lock()
 		p.tpl, err = Parse(p.source)
-		if err != nil {
-			return nil, err
-		}
+		p.mu.Unlock()
+		p.mu.RLock()
 	}
+	p.mu.RUnlock()
 
-	return p.tpl, nil
+	return p.tpl, err
 }

--- a/partial.go
+++ b/partial.go
@@ -92,6 +92,7 @@ func (p *partial) template() (*Template, error) {
 	var err error
 
 	p.mu.RLock()
+	defer p.mu.RUnlock()
 	if p.tpl == nil {
 		p.mu.RUnlock()
 		p.mu.Lock()
@@ -99,7 +100,6 @@ func (p *partial) template() (*Template, error) {
 		p.mu.Unlock()
 		p.mu.RLock()
 	}
-	p.mu.RUnlock()
 
 	return p.tpl, err
 }


### PR DESCRIPTION
## Context

This pull-request prevents a race-condition in which multiple callers invoke `partial.template()` and the template is actively being parsed, thus mutating `p.tpl` during multiple reads.